### PR TITLE
saco eventos de mouse al navegador de onepageScroll

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -82,6 +82,11 @@ text {
 	display: none;
 }
 
+.onepage-pagination{
+	pointer-events: none;
+}
+
+
 iframe {
   padding: 0;
   margin: 0;


### PR DESCRIPTION
El navegador se activaba cuando llegamos al slide del mapa porque esta en un z-index mayor al iframe y el div de id="viz", que era el que lo tapaba, no existe en esta vista.
