### PR TITLE
Tooltips caba

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -5030,3 +5030,18 @@ iframe {
   height: 50px;
   text-align: center;
   width: 100px; }
+
+#tooltipCABA {
+  color: #222;
+  background: #fff;
+  padding: .5em;
+  text-shadow: #f5f5f5 0 1px 0;
+  border-radius: 2px;
+  box-shadow: 0px 0px 2px 0px #a6a6a6;
+  opacity: 0.9;
+  position: absolute;
+  z-index: 999; }
+
+.main {
+  pointer-events: none;
+  z-index: 800; }

--- a/css/base.css
+++ b/css/base.css
@@ -5024,12 +5024,14 @@ iframe {
   margin: 0;
   width: 100%;
   height: 100%;
-  border: 0; }
+  border: 0;
+  pointer-events: auto !important; }
 
 #volverDelMapa {
   height: 50px;
   text-align: center;
-  width: 100px; }
+  width: 100px;
+  pointer-events: auto !important; }
 
 #tooltipCABA {
   color: #222;
@@ -5045,3 +5047,6 @@ iframe {
 .main {
   pointer-events: none;
   z-index: 800; }
+
+.main section .arrow {
+  pointer-events: auto !important; }

--- a/css/base.css
+++ b/css/base.css
@@ -1,4 +1,4 @@
-@charset "UTF-8";
+@charset "CP850";
 @import url(animate.min.css);
 @import url("http://fonts.googleapis.com/css?family=Lato:300,400,700");
 @font-face {
@@ -5017,3 +5017,16 @@ body.disabled-onepage-scroll, .disabled-onepage-scroll .onepage-wrapper, html {
   .default:active {
     -webkit-transform: perspective(600px) rotateX(45deg);
     -webkit-perspective: 600px; }
+
+/* CSS para el slide del iframe */
+iframe {
+  padding: 0;
+  margin: 0;
+  width: 100%;
+  height: 100%;
+  border: 0; }
+
+#volverDelMapa {
+  height: 50px;
+  text-align: center;
+  width: 100px; }

--- a/css/base.scss
+++ b/css/base.scss
@@ -809,3 +809,20 @@ iframe {
     text-align: center;
     width: 100px;
 }
+
+#tooltipCABA {
+  color: #222; 
+  background: #fff; 
+  padding: .5em; 
+  text-shadow: #f5f5f5 0 1px 0;
+  border-radius: 2px; 
+  box-shadow: 0px 0px 2px 0px #a6a6a6; 
+  opacity: 0.9; 
+  position: absolute;
+  z-index: 999;
+}
+
+.main{
+  pointer-events:none;
+  z-index: 800;  
+}

--- a/css/base.scss
+++ b/css/base.scss
@@ -794,3 +794,18 @@ body.disabled-onepage-scroll, .disabled-onepage-scroll .onepage-wrapper, html {
     -webkit-perspective: 600px;
   }
 }
+
+/* CSS para el slide del iframe */
+iframe {
+  padding: 0;
+  margin: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+#volverDelMapa{
+    height: 50px;
+    text-align: center;
+    width: 100px;
+}

--- a/css/base.scss
+++ b/css/base.scss
@@ -802,12 +802,15 @@ iframe {
   width: 100%;
   height: 100%;
   border: 0;
+  pointer-events: auto !important;
 }
 
 #volverDelMapa{
     height: 50px;
     text-align: center;
     width: 100px;
+    pointer-events: auto !important;
+
 }
 
 #tooltipCABA {
@@ -823,6 +826,10 @@ iframe {
 }
 
 .main{
-  pointer-events:none;
+  pointer-events: none;
   z-index: 800;  
+}
+
+.main section .arrow{
+  pointer-events: auto !important;
 }

--- a/css/estilosMapaInteractivo.css
+++ b/css/estilosMapaInteractivo.css
@@ -67,7 +67,7 @@ body {
 
 .cartodb-popup-cont{
     width: 450px !important;;
-    height: 300px !important;;
+    height: 320px !important;;
 }
 .cartodb-infowindow {
     position: fixed !important;
@@ -75,7 +75,7 @@ body {
 .cartodb-popup-content-wrapper {
     background: rgba(255, 255, 255, 1) !important;
     width: 450px !important;
-    height: 300px !important;
+    height: 320px !important;
     max-width: 450px !important;
     -webkit-box-shadow: 0px 0px 5px 5px rgba(0,0,0,0.25);
     -moz-box-shadow: 0px 0px 5px 5px rgba(0,0,0,0.25);

--- a/css/style.css
+++ b/css/style.css
@@ -108,3 +108,16 @@ div#dropdown-nivel {
 	left: 0;
 	z-index: 800;
 }
+.hidden { 
+  display: none; 
+}
+div.tooltip {
+  color: #222; 
+  background: #fff; 
+  padding: .5em; 
+  text-shadow: #f5f5f5 0 1px 0;
+  border-radius: 2px; 
+  box-shadow: 0px 0px 2px 0px #a6a6a6; 
+  opacity: 0.9; 
+  position: absolute;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -101,23 +101,6 @@ tspan.nivelLink:hover {
 	pointer-events: none;
 }
 
-
-iframe {
-  padding: 0;
-  margin: 0;
-  width: 100%;
-  height: 100%;
-	border: 0;
-}
-
-#volverDelMapa{
-    height: 50px;
-    position: inherit;
-    right: 0;
-    text-align: center;
-    width: 100px;
-}
-
 div#dropdown-nivel {
 	display: none;
 	position: fixed;

--- a/index.html
+++ b/index.html
@@ -142,7 +142,9 @@
           <div id="volverDelMapa">
             <a href="#" class="prev-section"><button class="btn btn-default volverMapa"><span class="glyphicon glyphicon-chevron-up"></span></button></a>
           </div>
+          <!-- Comento momentariamente para debug (nico)
         <iframe src="mapaInteractivo.html"></iframe>
+          -->
       </section>
   </div>
     <script type="text/javascript" src="js/efectos-ui.js"></script>

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
 
   </head>
   <body>
-
+  
 
   <header>
     <div class="header-gcba navbar navbar-default navbar-static-top" id="top" role="navigation">
@@ -124,6 +124,7 @@
 
     </div>
 
+    
     <div class="main">
       <!-- Secciones -->
       <section id="landing" class="active">
@@ -136,6 +137,7 @@
             <a href="#" class="arrow next-section"><span class="glyphicon glyphicon-chevron-down"></span></a>
       </section>
       <section id="comuna">
+            <div id="tooltipCABA">TT</div>
             <a href="#" class="arrow next-section"><span class="glyphicon glyphicon-chevron-down"></span></a>
       </section>
       <section id="mapa">
@@ -147,10 +149,12 @@
           -->
       </section>
   </div>
+      
+
     <script type="text/javascript" src="js/efectos-ui.js"></script>
     <script type="text/javascript" src="js/viz_educacion.js"></script>
     <script type="text/javascript" src="js/mapa_de_caba.js"></script>
     <script type="text/javascript" src="js/filtros.js"></script>
-
+  
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -144,9 +144,7 @@
           <div id="volverDelMapa">
             <a href="#" class="prev-section"><button class="btn btn-default volverMapa"><span class="glyphicon glyphicon-chevron-up"></span></button></a>
           </div>
-          <!-- Comento momentariamente para debug (nico)
-        <iframe src="mapaInteractivo.html"></iframe>
-          -->
+          <iframe src="mapaInteractivo.html"></iframe>
       </section>
   </div>
       

--- a/index.html
+++ b/index.html
@@ -127,8 +127,7 @@
       </section>
       <section id="comuna">
             <div id="tooltipCABA"></div>
-            <a href="#" class="arrow next-section"><span class="glyphicon glyphicon-chevron-down"></span></a>
-          <h2 class="animated fadeIn">Nuevos alumnos del sistema educativo de gestión estatal de la Ciudad.</h2>
+            <h2 class="animated fadeIn">Nuevos alumnos del sistema educativo de gestión estatal de la Ciudad.</h2>
       </section>
       <section id="mapa">
           <div id="volverDelMapa">

--- a/js/mapa_de_caba.js
+++ b/js/mapa_de_caba.js
@@ -1,4 +1,6 @@
 // Crear SVG para los circulos
+$("#tooltipCABA").hide();
+
 var svg = d3.select("#mapaCABA")
          .append("svg")
          .attr("width", mapaSvg.ancho)
@@ -11,7 +13,15 @@ queue()
     .defer(d3.json, "data/data.json")
     .await(ready);
 
+
 function ready(error, comunas, data) {
+  var mousePos = [];
+
+  $(document).mousemove(function(event) {
+    mousePos[0] = event.clientX;
+    mousePos[1] = event.clientY;
+  });
+
   var maximo = 0,
       minimo = Number.MAX_VALUE;
 
@@ -25,6 +35,8 @@ function ready(error, comunas, data) {
     }
   }
 
+
+
   var color = d3.scale.linear()
     .domain([minimo, maximo])
     .range(["#eaeaea", "#1977DD"]);
@@ -32,7 +44,6 @@ function ready(error, comunas, data) {
   svg.select(".caba").remove();
 
   svg.append("g")
-
       .attr("class", "caba")
     .selectAll("path")
       .data(topojson.feature(comunas, comunas.objects.comunas).features)
@@ -40,7 +51,23 @@ function ready(error, comunas, data) {
       .attr("d", d3.geo.path().projection(d3.geo.mercator().scale(157000/2).center([-58.20000,-34.68102])))
       .style("fill", function(d) { return color(data.comunas[nivelActivo][d.properties.comuna]);})
       .attr("title", function(d) { return data.comunas[nivelActivo][d.properties.comuna] + " nuevos alumnos";})
-      .on("mouseover", function(){d3.select(this).style("stroke", "#ffffff");})
-      .on("mouseout", function(){d3.select(this).style("stroke", "transparent");});
+      .on("mouseover", function(d){
+        $("#tooltipCABA").show();
+        d3.select(this).style("stroke", "#ffffff");
+        $("#tooltipCABA").text(data.comunas[nivelActivo][d.properties.comuna] + " nuevos alumnos");
+      })
+      .on("mouseout", function(){
+        $("#tooltipCABA").hide();
+        d3.select(this).style("stroke", "transparent");})
+      .on("mousemove", function(){
+        $("#tooltipCABA").show();
+        var mouse = d3.mouse(svg.node()).map( function(d) { return parseInt(d); } );
+        d3.select("#tooltipCABA")
+          .attr("style", 
+            function (){
+              return "left:"+ (mousePos[0]-60) +"px; top:"+ (mousePos[1]-50) +"px";
+            }
+            );
+      });
 }
 


### PR DESCRIPTION
Cambios pseudo-mayores
- Arreglé el css de infowindow de CartoDB que se caia si el nombre del establecimiento tenia dos líneas.
- Se agregan los tooltips de CABA y esto supone un cambio mayor en .main (Tiene pointer-events none y un z-index de 800)
